### PR TITLE
Phase 5: Enhanced Accessors

### DIFF
--- a/jalali_pandas/__init__.py
+++ b/jalali_pandas/__init__.py
@@ -7,32 +7,26 @@ for pandas, including custom dtypes, timestamps, and time series operations.
 
 from jalali_pandas._version import __version__
 
-# API functions
+# Accessors (new enhanced versions - imported LAST to override legacy)
+from jalali_pandas.accessors.dataframe import JalaliDataFrameAccessor  # noqa: E402
+from jalali_pandas.accessors.series import JalaliSeriesAccessor  # noqa: E402
 from jalali_pandas.api import (
     jalali_date_range,
     to_gregorian_datetime,
     to_jalali_datetime,
 )
 from jalali_pandas.core.arrays import JalaliDatetimeArray
-
-# Calendar utilities
 from jalali_pandas.core.calendar import (
     days_in_month,
     days_in_year,
     is_leap_year,
 )
 from jalali_pandas.core.dtypes import JalaliDatetimeDtype
-
-# Index
 from jalali_pandas.core.indexes import JalaliDatetimeIndex
-
-# Core types
 from jalali_pandas.core.timestamp import JalaliTimestamp
 
-# Accessors
+# Legacy accessors (imported first, will be overridden by new ones)
 from jalali_pandas.df_handler import JalaliDataframeAccessor
-
-# Frequency offsets
 from jalali_pandas.offsets import (
     JalaliMonthBegin,
     JalaliMonthEnd,
@@ -68,7 +62,10 @@ __all__ = [
     "JalaliQuarterEnd",
     "JalaliYearBegin",
     "JalaliYearEnd",
-    # Accessors
+    # Accessors (new enhanced versions)
+    "JalaliDataFrameAccessor",
+    "JalaliSeriesAccessor",
+    # Legacy accessors (for backward compatibility)
     "JalaliDataframeAccessor",
     "JalaliSerieAccessor",
 ]

--- a/jalali_pandas/__init__.py
+++ b/jalali_pandas/__init__.py
@@ -6,10 +6,8 @@ for pandas, including custom dtypes, timestamps, and time series operations.
 """
 
 from jalali_pandas._version import __version__
-
-# Accessors (new enhanced versions - imported LAST to override legacy)
-from jalali_pandas.accessors.dataframe import JalaliDataFrameAccessor  # noqa: E402
-from jalali_pandas.accessors.series import JalaliSeriesAccessor  # noqa: E402
+from jalali_pandas.accessors.dataframe import JalaliDataFrameAccessor
+from jalali_pandas.accessors.series import JalaliSeriesAccessor
 from jalali_pandas.api import (
     jalali_date_range,
     to_gregorian_datetime,
@@ -24,8 +22,6 @@ from jalali_pandas.core.calendar import (
 from jalali_pandas.core.dtypes import JalaliDatetimeDtype
 from jalali_pandas.core.indexes import JalaliDatetimeIndex
 from jalali_pandas.core.timestamp import JalaliTimestamp
-
-# Legacy accessors (imported first, will be overridden by new ones)
 from jalali_pandas.df_handler import JalaliDataframeAccessor
 from jalali_pandas.offsets import (
     JalaliMonthBegin,

--- a/jalali_pandas/accessors/__init__.py
+++ b/jalali_pandas/accessors/__init__.py
@@ -1,0 +1,9 @@
+"""Pandas accessors for Jalali datetime operations."""
+
+from jalali_pandas.accessors.dataframe import JalaliDataFrameAccessor
+from jalali_pandas.accessors.series import JalaliSeriesAccessor
+
+__all__ = [
+    "JalaliSeriesAccessor",
+    "JalaliDataFrameAccessor",
+]

--- a/jalali_pandas/accessors/dataframe.py
+++ b/jalali_pandas/accessors/dataframe.py
@@ -1,0 +1,390 @@
+"""Enhanced DataFrame accessor for Jalali datetime operations."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+
+import jdatetime
+import pandas as pd
+from pandas.core.groupby.generic import DataFrameGroupBy as DataFrameGroupByRuntime
+
+if TYPE_CHECKING:
+    from pandas.core.groupby.generic import DataFrameGroupBy
+
+    DataFrameGroupByT = DataFrameGroupBy[pd.DataFrame, Any]
+else:
+    DataFrameGroupByT = DataFrameGroupByRuntime
+
+
+@pd.api.extensions.register_dataframe_accessor("jalali")
+class JalaliDataFrameAccessor:
+    """Enhanced accessor for Jalali datetime operations on pandas DataFrames.
+
+    Provides methods for working with Jalali (Persian/Shamsi) dates in
+    pandas DataFrames, including groupby, resample, and column conversion.
+
+    Attributes:
+        jdate: Name of the detected Jalali date column.
+        columns: DataFrame columns.
+
+    Examples:
+        >>> import pandas as pd
+        >>> import jalali_pandas
+        >>> df = pd.DataFrame({
+        ...     'date': pd.date_range('2023-03-21', periods=5),
+        ...     'value': [1, 2, 3, 4, 5]
+        ... })
+        >>> df['jdate'] = df['date'].jalali.to_jalali()
+        >>> df.jalali.groupby('month').sum()
+    """
+
+    TEMP_COLUMNS: list[str] = [
+        "__year",
+        "__month",
+        "__quarter",
+        "__weekday",
+        "__day",
+        "__week",
+        "__dayofyear",
+    ]
+
+    def __init__(self, pandas_obj: pd.DataFrame) -> None:
+        """Initialize the accessor.
+
+        Args:
+            pandas_obj: A pandas DataFrame containing Jalali datetime data.
+        """
+        self._obj: pd.DataFrame = pandas_obj
+        self.columns: pd.Index[Any] = self._obj.columns
+        self.jdate: str = "jdate"
+        self._validate()
+
+    def _validate(self) -> None:
+        """Check if the DataFrame has a jdatetime column.
+
+        Raises:
+            ValueError: If no jdatetime column is found.
+        """
+        for col in self.columns:
+            if len(self._obj) > 0:
+                first_val = self._obj[col].iloc[0]
+                if isinstance(first_val, (jdatetime.date, jdatetime.datetime)):
+                    self.jdate = str(col)
+                    return
+        raise ValueError("No jdatetime column found in the dataframe.")
+
+    def set_date_column(self, column: str) -> JalaliDataFrameAccessor:
+        """Set the Jalali date column to use for operations.
+
+        Args:
+            column: Name of the column containing Jalali dates.
+
+        Returns:
+            Self for method chaining.
+
+        Raises:
+            ValueError: If column doesn't exist or doesn't contain jdatetime.
+        """
+        if column not in self.columns:
+            raise ValueError(f"Column '{column}' not found in DataFrame.")
+
+        if len(self._obj) > 0:
+            first_val = self._obj[column].iloc[0]
+            if not isinstance(first_val, (jdatetime.date, jdatetime.datetime)):
+                raise ValueError(
+                    f"Column '{column}' does not contain jdatetime objects."
+                )
+
+        self.jdate = column
+        return self
+
+    @property
+    def _df(self) -> pd.DataFrame:
+        """Generate temp DataFrame with extracted date components.
+
+        Returns:
+            DataFrame with year, month, day, quarter, weekday columns.
+        """
+        df = self._obj.copy()
+        df["__year"] = df[self.jdate].jalali.year
+        df["__month"] = df[self.jdate].jalali.month
+        df["__day"] = df[self.jdate].jalali.day
+        df["__quarter"] = df[self.jdate].jalali.quarter
+        df["__weekday"] = df[self.jdate].jalali.weekday
+        df["__week"] = df[self.jdate].jalali.week
+        df["__dayofyear"] = df[self.jdate].jalali.dayofyear
+        return df
+
+    def _clean_groupby(self, group: DataFrameGroupByT) -> DataFrameGroupByT:
+        """Clean the groupby object by removing temp columns.
+
+        Args:
+            group: The groupby object to clean.
+
+        Returns:
+            Cleaned groupby object with only original columns.
+        """
+        numeric_columns: pd.Index[Any] = cast(
+            pd.DataFrame, self._obj.select_dtypes(include="number")
+        ).columns
+        remaining_columns = [
+            col
+            for col in numeric_columns
+            if col in set(self.columns).difference(self.TEMP_COLUMNS)
+        ]
+        if not remaining_columns:
+            return group
+        return cast(DataFrameGroupByT, group[remaining_columns])
+
+    def groupby(self, grouper: str = "md") -> DataFrameGroupByT:
+        """Group by Jalali date components.
+
+        Args:
+            grouper: Grouping key. Options:
+                - 'year': Group by year
+                - 'month': Group by month
+                - 'day': Group by day
+                - 'week': Group by week number
+                - 'dayofweek': Group by day of week
+                - 'dayofmonth': Group by day of month (alias for 'day')
+                - 'quarter': Group by quarter
+                - 'dayofyear': Group by day of year
+                - 'ym': Group by year and month
+                - 'yq': Group by year and quarter
+                - 'ymd': Group by year, month, and day
+                - 'md': Group by month and day (default)
+
+        Returns:
+            DataFrameGroupBy object.
+
+        Raises:
+            ValueError: If grouper is not a valid option.
+        """
+        possible_keys = [
+            "year",
+            "month",
+            "day",
+            "week",
+            "dayofweek",
+            "dayofmonth",
+            "quarter",
+            "dayofyear",
+            "ym",
+            "yq",
+            "ymd",
+            "md",
+        ]
+        df = self._df
+        if grouper not in possible_keys:
+            raise ValueError(
+                f"{grouper} is not a valid groupby type. Choose from {possible_keys}"
+            )
+
+        keys: dict[str, list[str]] = {
+            "md": ["month", "day"],
+            "ym": ["year", "month"],
+            "yq": ["year", "quarter"],
+            "ymd": ["year", "month", "day"],
+        }
+        grouper_cols: list[str]
+        if grouper in keys:
+            grouper_cols = [f"__{g}" for g in keys[grouper]]
+        elif grouper == "dayofmonth":
+            grouper_cols = ["__day"]
+        else:
+            grouper_cols = [f"__{grouper}"]
+
+        group = cast(DataFrameGroupByT, df.groupby(grouper_cols))
+        return self._clean_groupby(group)
+
+    def resample(self, resample_type: str) -> pd.DataFrame:
+        """Resample by Jalali frequency.
+
+        Groups the DataFrame by Jalali calendar periods and aggregates.
+
+        Args:
+            resample_type: The resample frequency. Options:
+                - 'month': Group by Jalali month
+                - 'quarter': Group by Jalali quarter
+                - 'year': Group by Jalali year
+                - 'week': Group by Jalali week
+
+        Returns:
+            DataFrame with aggregated values grouped by the specified period.
+
+        Raises:
+            ValueError: If resample_type is not valid.
+
+        Examples:
+            >>> df.jalali.resample('month')
+            >>> df.jalali.resample('quarter')
+        """
+        valid_types = ["month", "quarter", "year", "week"]
+        if resample_type not in valid_types:
+            raise ValueError(
+                f"{resample_type} is not a valid resample type. "
+                f"Choose from {valid_types}"
+            )
+
+        type_to_groupby: dict[str, str] = {
+            "month": "ym",
+            "quarter": "yq",
+            "year": "year",
+            "week": "week",
+        }
+
+        groupby_key = type_to_groupby[resample_type]
+        return self.groupby(groupby_key).sum(numeric_only=True).reset_index(drop=True)
+
+    def convert_columns(
+        self,
+        columns: list[str] | str,
+        to_jalali: bool = True,
+        format: str = "%Y-%m-%d",
+    ) -> pd.DataFrame:
+        """Convert date columns between Jalali and Gregorian.
+
+        Args:
+            columns: Column name(s) to convert.
+            to_jalali: If True, convert Gregorian to Jalali.
+                If False, convert Jalali to Gregorian. Defaults to True.
+            format: Format string for parsing string dates. Defaults to "%Y-%m-%d".
+
+        Returns:
+            DataFrame with converted columns.
+
+        Examples:
+            >>> df.jalali.convert_columns('date', to_jalali=True)
+            >>> df.jalali.convert_columns(['date1', 'date2'], to_jalali=False)
+        """
+        df = self._obj.copy()
+
+        if isinstance(columns, str):
+            columns = [columns]
+
+        for col in columns:
+            if col not in df.columns:
+                raise ValueError(f"Column '{col}' not found in DataFrame.")
+
+            if to_jalali:
+                df[col] = df[col].jalali.to_jalali()
+            else:
+                if df[col].dtype == object:
+                    first_val = (
+                        df[col].dropna().iloc[0] if len(df[col].dropna()) > 0 else None
+                    )
+                    if isinstance(first_val, str):
+                        df[col] = df[col].jalali.parse_jalali(format)
+                df[col] = df[col].jalali.to_gregorian()
+
+        return df
+
+    def to_period(self, freq: str = "M") -> pd.DataFrame:
+        """Convert Jalali dates to period representation.
+
+        Args:
+            freq: Frequency for period. Options:
+                - 'Y': Year
+                - 'Q': Quarter
+                - 'M': Month (default)
+                - 'W': Week
+                - 'D': Day
+
+        Returns:
+            DataFrame with period column added.
+        """
+        df = self._obj.copy()
+
+        def get_period(x: Any) -> str | None:
+            if pd.isna(x):
+                return None
+            if freq == "Y":
+                return f"{x.year}"
+            elif freq == "Q":
+                q = (x.month - 1) // 3 + 1
+                return f"{x.year}Q{q}"
+            elif freq == "M":
+                return f"{x.year}-{x.month:02d}"
+            elif freq == "W":
+                from jalali_pandas.core.calendar import week_of_year
+
+                w = week_of_year(x.year, x.month, x.day)
+                return f"{x.year}W{w:02d}"
+            elif freq == "D":
+                return f"{x.year}-{x.month:02d}-{x.day:02d}"
+            else:
+                raise ValueError(f"Unsupported frequency: {freq}")
+
+        df[f"{self.jdate}_period"] = df[self.jdate].apply(get_period)
+        return df
+
+    def filter_by_year(self, year: int | list[int]) -> pd.DataFrame:
+        """Filter DataFrame by Jalali year(s).
+
+        Args:
+            year: Year or list of years to filter by.
+
+        Returns:
+            Filtered DataFrame.
+        """
+        years = [year] if isinstance(year, int) else year
+        mask = self._obj[self.jdate].jalali.year.isin(years)
+        return cast(pd.DataFrame, self._obj[mask].copy())
+
+    def filter_by_month(self, month: int | list[int]) -> pd.DataFrame:
+        """Filter DataFrame by Jalali month(s).
+
+        Args:
+            month: Month or list of months to filter by (1-12).
+
+        Returns:
+            Filtered DataFrame.
+        """
+        months = [month] if isinstance(month, int) else month
+        mask = self._obj[self.jdate].jalali.month.isin(months)
+        return cast(pd.DataFrame, self._obj[mask].copy())
+
+    def filter_by_quarter(self, quarter: int | list[int]) -> pd.DataFrame:
+        """Filter DataFrame by Jalali quarter(s).
+
+        Args:
+            quarter: Quarter or list of quarters to filter by (1-4).
+
+        Returns:
+            Filtered DataFrame.
+        """
+        quarters = [quarter] if isinstance(quarter, int) else quarter
+        mask = self._obj[self.jdate].jalali.quarter.isin(quarters)
+        return cast(pd.DataFrame, self._obj[mask].copy())
+
+    def filter_by_date_range(
+        self,
+        start: str | jdatetime.date | None = None,
+        end: str | jdatetime.date | None = None,
+    ) -> pd.DataFrame:
+        """Filter DataFrame by Jalali date range.
+
+        Args:
+            start: Start date (inclusive). Can be string 'YYYY-MM-DD' or jdatetime.
+            end: End date (inclusive). Can be string 'YYYY-MM-DD' or jdatetime.
+
+        Returns:
+            Filtered DataFrame.
+        """
+        df = self._obj.copy()
+        mask = pd.Series([True] * len(df), index=df.index)
+
+        if start is not None:
+            if isinstance(start, str):
+                start = jdatetime.datetime.strptime(start, "%Y-%m-%d")
+            mask = mask & (df[self.jdate] >= start)
+
+        if end is not None:
+            if isinstance(end, str):
+                end = jdatetime.datetime.strptime(end, "%Y-%m-%d")
+            mask = mask & (df[self.jdate] <= end)
+
+        return cast(pd.DataFrame, df[mask].copy())
+
+
+__all__ = ["JalaliDataFrameAccessor"]

--- a/jalali_pandas/accessors/series.py
+++ b/jalali_pandas/accessors/series.py
@@ -680,10 +680,13 @@ class JalaliSeriesAccessor:
         """
         self._validate()
         gregorian = self.to_gregorian()
-        dt_series: pd.Series = pd.to_datetime(gregorian)
+        dt_index = pd.DatetimeIndex(pd.to_datetime(gregorian))
+        localized = dt_index.tz_localize(
+            tz, ambiguous=ambiguous, nonexistent=nonexistent
+        )
         return cast(
             pd.Series,
-            dt_series.dt.tz_localize(tz, ambiguous=ambiguous, nonexistent=nonexistent),
+            pd.Series(localized, index=self._obj.index, name=self._obj.name),
         )
 
     def tz_convert(self, tz: dt_tzinfo | str | None) -> pd.Series:
@@ -700,8 +703,12 @@ class JalaliSeriesAccessor:
         """
         self._validate()
         gregorian = self.to_gregorian()
-        dt_series: pd.Series = pd.to_datetime(gregorian)
-        return cast(pd.Series, dt_series.dt.tz_convert(tz))
+        dt_index = pd.DatetimeIndex(pd.to_datetime(gregorian))
+        converted = dt_index.tz_convert(tz)
+        return cast(
+            pd.Series,
+            pd.Series(converted, index=self._obj.index, name=self._obj.name),
+        )
 
 
 __all__ = ["JalaliSeriesAccessor"]

--- a/jalali_pandas/accessors/series.py
+++ b/jalali_pandas/accessors/series.py
@@ -1,0 +1,707 @@
+"""Enhanced Series accessor for Jalali datetime operations."""
+
+from __future__ import annotations
+
+from datetime import time
+from datetime import tzinfo as dt_tzinfo
+from typing import Any, Literal, cast
+
+import jdatetime
+import numpy as np
+import pandas as pd
+
+from jalali_pandas.core.calendar import (
+    MONTH_NAMES_EN,
+    MONTH_NAMES_FA,
+    WEEKDAY_NAMES_EN,
+    WEEKDAY_NAMES_FA,
+    day_of_year,
+    days_in_month,
+    is_leap_year,
+    quarter_of_month,
+    week_of_year,
+    weekday_of_jalali,
+)
+
+
+@pd.api.extensions.register_series_accessor("jalali")
+class JalaliSeriesAccessor:
+    """Enhanced accessor for Jalali datetime operations on pandas Series.
+
+    Provides properties and methods for working with Jalali (Persian/Shamsi)
+    dates in pandas Series.
+
+    Attributes:
+        year: Jalali year component.
+        month: Jalali month component (1-12).
+        day: Jalali day component.
+        hour: Hour component (0-23).
+        minute: Minute component (0-59).
+        second: Second component (0-59).
+        microsecond: Microsecond component.
+        nanosecond: Nanosecond component.
+        quarter: Quarter of the year (1-4).
+        weekday: Day of week (0=Saturday, 6=Friday).
+        dayofweek: Alias for weekday.
+        dayofyear: Day of year (1-366).
+        daysinmonth: Number of days in the month.
+        week: Week of year.
+        weekofyear: Alias for week.
+        is_leap_year: Whether the year is a leap year.
+        is_month_start: Whether the date is the first day of the month.
+        is_month_end: Whether the date is the last day of the month.
+        is_quarter_start: Whether the date is the first day of a quarter.
+        is_quarter_end: Whether the date is the last day of a quarter.
+        is_year_start: Whether the date is the first day of the year.
+        is_year_end: Whether the date is the last day of the year.
+        date: Date part (time set to midnight).
+        time: Time part as Python time objects.
+
+    Examples:
+        >>> import pandas as pd
+        >>> import jalali_pandas
+        >>> s = pd.Series(pd.date_range("2023-03-21", periods=5))
+        >>> s.jalali.to_jalali()
+        >>> s.jalali.year
+        >>> s.jalali.month_name()
+    """
+
+    def __init__(self, pandas_obj: pd.Series) -> None:
+        """Initialize the accessor.
+
+        Args:
+            pandas_obj: A pandas Series containing datetime data.
+        """
+        self._obj: pd.Series = pandas_obj
+
+    def _validate(self) -> None:
+        """Validate pandas series contains jdatetime objects.
+
+        Raises:
+            TypeError: If series doesn't contain jdatetime or string dates.
+        """
+        if len(self._obj) == 0:
+            return
+        first_valid = (
+            self._obj.dropna().iloc[0] if len(self._obj.dropna()) > 0 else None
+        )
+        if first_valid is not None and not isinstance(
+            first_valid, (str, jdatetime.date, jdatetime.datetime)
+        ):
+            raise TypeError("pandas series must be jdatetime or string of jdate")
+
+    def _get_jdate_attr(self, attr: str) -> pd.Series:
+        """Get an attribute from jdatetime objects in the series.
+
+        Args:
+            attr: Attribute name to get.
+
+        Returns:
+            Series with the attribute values.
+        """
+        self._validate()
+
+        def get_attr(x: Any) -> Any:
+            if pd.isna(x):
+                return np.nan
+            val = getattr(x, attr, None)
+            if callable(val):
+                return val()
+            return val
+
+        return cast(pd.Series, self._obj.apply(get_attr))
+
+    # -------------------------------------------------------------------------
+    # Conversion Methods
+    # -------------------------------------------------------------------------
+
+    def to_jalali(self) -> pd.Series:
+        """Convert Gregorian datetime to Jalali datetime.
+
+        Returns:
+            Series of jdatetime objects.
+        """
+        return cast(
+            pd.Series,
+            self._obj.apply(
+                lambda x: jdatetime.datetime.fromgregorian(date=x)
+                if not pd.isna(x)
+                else pd.NaT
+            ),
+        )
+
+    def to_gregorian(self) -> pd.Series:
+        """Convert Jalali datetime to Gregorian datetime.
+
+        Returns:
+            Series of Python datetime objects.
+        """
+        self._validate()
+        return cast(
+            pd.Series,
+            self._obj.apply(lambda x: x.togregorian() if not pd.isna(x) else pd.NaT),
+        )
+
+    def parse_jalali(self, format: str = "%Y-%m-%d") -> pd.Series:
+        """Parse string dates to jdatetime objects.
+
+        Args:
+            format: strftime format string. Defaults to "%Y-%m-%d".
+
+        Returns:
+            Series of jdatetime objects.
+        """
+        return cast(
+            pd.Series,
+            self._obj.apply(
+                lambda x: jdatetime.datetime.strptime(x, format)
+                if not pd.isna(x)
+                else pd.NaT
+            ),
+        )
+
+    # -------------------------------------------------------------------------
+    # Basic Properties
+    # -------------------------------------------------------------------------
+
+    @property
+    def year(self) -> pd.Series:
+        """Get Jalali year."""
+        return self._get_jdate_attr("year")
+
+    @property
+    def month(self) -> pd.Series:
+        """Get Jalali month (1-12)."""
+        return self._get_jdate_attr("month")
+
+    @property
+    def day(self) -> pd.Series:
+        """Get Jalali day."""
+        return self._get_jdate_attr("day")
+
+    @property
+    def hour(self) -> pd.Series:
+        """Get hour component (0-23)."""
+        return self._get_jdate_attr("hour")
+
+    @property
+    def minute(self) -> pd.Series:
+        """Get minute component (0-59)."""
+        return self._get_jdate_attr("minute")
+
+    @property
+    def second(self) -> pd.Series:
+        """Get second component (0-59)."""
+        return self._get_jdate_attr("second")
+
+    @property
+    def microsecond(self) -> pd.Series:
+        """Get microsecond component."""
+        return self._get_jdate_attr("microsecond")
+
+    @property
+    def nanosecond(self) -> pd.Series:
+        """Get nanosecond component (always 0 for jdatetime)."""
+        self._validate()
+        return cast(
+            pd.Series,
+            self._obj.apply(lambda x: 0 if not pd.isna(x) else np.nan),
+        )
+
+    @property
+    def weekday(self) -> pd.Series:
+        """Get Jalali weekday (0=Saturday, 6=Friday)."""
+        return self._get_jdate_attr("weekday")
+
+    @property
+    def dayofweek(self) -> pd.Series:
+        """Alias for weekday."""
+        return self.weekday
+
+    @property
+    def weeknumber(self) -> pd.Series:
+        """Get week number of the year."""
+        return self._get_jdate_attr("weeknumber")
+
+    @property
+    def week(self) -> pd.Series:
+        """Get week number of the year."""
+        self._validate()
+
+        def get_week(x: Any) -> Any:
+            if pd.isna(x):
+                return np.nan
+            return week_of_year(x.year, x.month, x.day)
+
+        return cast(pd.Series, self._obj.apply(get_week))
+
+    @property
+    def weekofyear(self) -> pd.Series:
+        """Alias for week."""
+        return self.week
+
+    @property
+    def quarter(self) -> pd.Series:
+        """Get Jalali quarter (1-4)."""
+        self._validate()
+
+        def get_quarter(x: Any) -> Any:
+            if pd.isna(x):
+                return np.nan
+            return quarter_of_month(x.month)
+
+        return cast(pd.Series, self._obj.apply(get_quarter))
+
+    @property
+    def dayofyear(self) -> pd.Series:
+        """Get day of year (1-366)."""
+        self._validate()
+
+        def get_dayofyear(x: Any) -> Any:
+            if pd.isna(x):
+                return np.nan
+            return day_of_year(x.year, x.month, x.day)
+
+        return cast(pd.Series, self._obj.apply(get_dayofyear))
+
+    @property
+    def daysinmonth(self) -> pd.Series:
+        """Get number of days in the month."""
+        self._validate()
+
+        def get_daysinmonth(x: Any) -> Any:
+            if pd.isna(x):
+                return np.nan
+            return days_in_month(x.year, x.month)
+
+        return cast(pd.Series, self._obj.apply(get_daysinmonth))
+
+    @property
+    def days_in_month(self) -> pd.Series:
+        """Alias for daysinmonth."""
+        return self.daysinmonth
+
+    # -------------------------------------------------------------------------
+    # Boolean Properties
+    # -------------------------------------------------------------------------
+
+    @property
+    def is_leap_year(self) -> pd.Series:
+        """Check if the year is a leap year."""
+        self._validate()
+
+        def check_leap(x: Any) -> Any:
+            if pd.isna(x):
+                return False
+            return is_leap_year(x.year)
+
+        return cast(pd.Series, self._obj.apply(check_leap))
+
+    @property
+    def is_month_start(self) -> pd.Series:
+        """Check if the date is the first day of the month."""
+        self._validate()
+
+        def check_month_start(x: Any) -> Any:
+            if pd.isna(x):
+                return False
+            return x.day == 1
+
+        return cast(pd.Series, self._obj.apply(check_month_start))
+
+    @property
+    def is_month_end(self) -> pd.Series:
+        """Check if the date is the last day of the month."""
+        self._validate()
+
+        def check_month_end(x: Any) -> Any:
+            if pd.isna(x):
+                return False
+            return x.day == days_in_month(x.year, x.month)
+
+        return cast(pd.Series, self._obj.apply(check_month_end))
+
+    @property
+    def is_quarter_start(self) -> pd.Series:
+        """Check if the date is the first day of a quarter."""
+        self._validate()
+
+        def check_quarter_start(x: Any) -> Any:
+            if pd.isna(x):
+                return False
+            return x.month in (1, 4, 7, 10) and x.day == 1
+
+        return cast(pd.Series, self._obj.apply(check_quarter_start))
+
+    @property
+    def is_quarter_end(self) -> pd.Series:
+        """Check if the date is the last day of a quarter."""
+        self._validate()
+
+        def check_quarter_end(x: Any) -> Any:
+            if pd.isna(x):
+                return False
+            if x.month not in (3, 6, 9, 12):
+                return False
+            return x.day == days_in_month(x.year, x.month)
+
+        return cast(pd.Series, self._obj.apply(check_quarter_end))
+
+    @property
+    def is_year_start(self) -> pd.Series:
+        """Check if the date is the first day of the year (Nowruz)."""
+        self._validate()
+
+        def check_year_start(x: Any) -> Any:
+            if pd.isna(x):
+                return False
+            return x.month == 1 and x.day == 1
+
+        return cast(pd.Series, self._obj.apply(check_year_start))
+
+    @property
+    def is_year_end(self) -> pd.Series:
+        """Check if the date is the last day of the year."""
+        self._validate()
+
+        def check_year_end(x: Any) -> Any:
+            if pd.isna(x):
+                return False
+            return x.month == 12 and x.day == days_in_month(x.year, 12)
+
+        return cast(pd.Series, self._obj.apply(check_year_end))
+
+    # -------------------------------------------------------------------------
+    # Date/Time Properties
+    # -------------------------------------------------------------------------
+
+    @property
+    def date(self) -> pd.Series:
+        """Get date part (time set to midnight)."""
+        self._validate()
+
+        def get_date(x: Any) -> Any:
+            if pd.isna(x):
+                return pd.NaT
+            if isinstance(x, jdatetime.datetime):
+                return jdatetime.datetime(x.year, x.month, x.day)
+            return x
+
+        return cast(pd.Series, self._obj.apply(get_date))
+
+    @property
+    def time(self) -> pd.Series:
+        """Get time part as Python time objects."""
+        self._validate()
+
+        def get_time(x: Any) -> Any:
+            if pd.isna(x):
+                return None
+            if isinstance(x, jdatetime.datetime):
+                return time(
+                    hour=x.hour,
+                    minute=x.minute,
+                    second=x.second,
+                    microsecond=x.microsecond,
+                )
+            return time(0, 0, 0)
+
+        return cast(pd.Series, self._obj.apply(get_time))
+
+    # -------------------------------------------------------------------------
+    # String Methods
+    # -------------------------------------------------------------------------
+
+    def strftime(self, date_format: str) -> pd.Series:
+        """Format dates as strings.
+
+        Args:
+            date_format: strftime format string.
+
+        Returns:
+            Series of formatted strings.
+        """
+        self._validate()
+
+        def format_date(x: Any) -> Any:
+            if pd.isna(x):
+                return None
+            return x.strftime(date_format)
+
+        return cast(pd.Series, self._obj.apply(format_date))
+
+    def month_name(self, locale: Literal["fa", "en"] = "en") -> pd.Series:
+        """Get month names.
+
+        Args:
+            locale: Language for month names. 'fa' for Persian, 'en' for English.
+                Defaults to 'en'.
+
+        Returns:
+            Series of month names.
+        """
+        self._validate()
+        names = MONTH_NAMES_FA if locale == "fa" else MONTH_NAMES_EN
+
+        def get_month_name(x: Any) -> Any:
+            if pd.isna(x):
+                return None
+            return names[x.month - 1]
+
+        return cast(pd.Series, self._obj.apply(get_month_name))
+
+    def day_name(self, locale: Literal["fa", "en"] = "en") -> pd.Series:
+        """Get day names.
+
+        Args:
+            locale: Language for day names. 'fa' for Persian, 'en' for English.
+                Defaults to 'en'.
+
+        Returns:
+            Series of day names.
+        """
+        self._validate()
+        names = WEEKDAY_NAMES_FA if locale == "fa" else WEEKDAY_NAMES_EN
+
+        def get_day_name(x: Any) -> Any:
+            if pd.isna(x):
+                return None
+            wd = weekday_of_jalali(x.year, x.month, x.day)
+            return names[wd]
+
+        return cast(pd.Series, self._obj.apply(get_day_name))
+
+    # -------------------------------------------------------------------------
+    # Normalization Methods
+    # -------------------------------------------------------------------------
+
+    def normalize(self) -> pd.Series:
+        """Normalize dates to midnight.
+
+        Returns:
+            Series with time components set to zero.
+        """
+        self._validate()
+
+        def normalize_date(x: Any) -> Any:
+            if pd.isna(x):
+                return pd.NaT
+            if isinstance(x, jdatetime.datetime):
+                return jdatetime.datetime(x.year, x.month, x.day)
+            return x
+
+        return cast(pd.Series, self._obj.apply(normalize_date))
+
+    def floor(self, freq: str) -> pd.Series:
+        """Floor dates to specified frequency.
+
+        Args:
+            freq: Frequency string. Supported: 'D' (day), 'h' (hour),
+                'min' (minute), 's' (second).
+
+        Returns:
+            Series with floored dates.
+        """
+        self._validate()
+
+        def floor_date(x: Any) -> Any:
+            if pd.isna(x):
+                return pd.NaT
+            if not isinstance(x, jdatetime.datetime):
+                return x
+
+            if freq in ("D", "d"):
+                return jdatetime.datetime(x.year, x.month, x.day)
+            elif freq in ("h", "H"):
+                return jdatetime.datetime(x.year, x.month, x.day, x.hour)
+            elif freq in ("min", "T"):
+                return jdatetime.datetime(x.year, x.month, x.day, x.hour, x.minute)
+            elif freq in ("s", "S"):
+                return jdatetime.datetime(
+                    x.year, x.month, x.day, x.hour, x.minute, x.second
+                )
+            else:
+                raise ValueError(f"Unsupported frequency: {freq}")
+
+        return cast(pd.Series, self._obj.apply(floor_date))
+
+    def ceil(self, freq: str) -> pd.Series:
+        """Ceil dates to specified frequency.
+
+        Args:
+            freq: Frequency string. Supported: 'D' (day), 'h' (hour),
+                'min' (minute), 's' (second).
+
+        Returns:
+            Series with ceiled dates.
+        """
+        self._validate()
+
+        def ceil_date(x: Any) -> Any:
+            if pd.isna(x):
+                return pd.NaT
+            if not isinstance(x, jdatetime.datetime):
+                return x
+
+            if freq in ("D", "d"):
+                if x.hour > 0 or x.minute > 0 or x.second > 0 or x.microsecond > 0:
+                    # Add one day
+                    greg = x.togregorian()
+                    greg = greg + pd.Timedelta(days=1)
+                    new_j = jdatetime.datetime.fromgregorian(datetime=greg)
+                    return jdatetime.datetime(new_j.year, new_j.month, new_j.day)
+                return jdatetime.datetime(x.year, x.month, x.day)
+            elif freq in ("h", "H"):
+                if x.minute > 0 or x.second > 0 or x.microsecond > 0:
+                    greg = x.togregorian()
+                    greg = greg + pd.Timedelta(hours=1)
+                    new_j = jdatetime.datetime.fromgregorian(datetime=greg)
+                    return jdatetime.datetime(
+                        new_j.year, new_j.month, new_j.day, new_j.hour
+                    )
+                return jdatetime.datetime(x.year, x.month, x.day, x.hour)
+            elif freq in ("min", "T"):
+                if x.second > 0 or x.microsecond > 0:
+                    greg = x.togregorian()
+                    greg = greg + pd.Timedelta(minutes=1)
+                    new_j = jdatetime.datetime.fromgregorian(datetime=greg)
+                    return jdatetime.datetime(
+                        new_j.year, new_j.month, new_j.day, new_j.hour, new_j.minute
+                    )
+                return jdatetime.datetime(x.year, x.month, x.day, x.hour, x.minute)
+            elif freq in ("s", "S"):
+                if x.microsecond > 0:
+                    greg = x.togregorian()
+                    greg = greg + pd.Timedelta(seconds=1)
+                    new_j = jdatetime.datetime.fromgregorian(datetime=greg)
+                    return jdatetime.datetime(
+                        new_j.year,
+                        new_j.month,
+                        new_j.day,
+                        new_j.hour,
+                        new_j.minute,
+                        new_j.second,
+                    )
+                return jdatetime.datetime(
+                    x.year, x.month, x.day, x.hour, x.minute, x.second
+                )
+            else:
+                raise ValueError(f"Unsupported frequency: {freq}")
+
+        return cast(pd.Series, self._obj.apply(ceil_date))
+
+    def round(self, freq: str) -> pd.Series:
+        """Round dates to specified frequency.
+
+        Args:
+            freq: Frequency string. Supported: 'D' (day), 'h' (hour),
+                'min' (minute), 's' (second).
+
+        Returns:
+            Series with rounded dates.
+        """
+        self._validate()
+
+        def round_date(x: Any) -> Any:
+            if pd.isna(x):
+                return pd.NaT
+            if not isinstance(x, jdatetime.datetime):
+                return x
+
+            if freq in ("D", "d"):
+                # Round to nearest day (12:00 is the midpoint)
+                if x.hour >= 12:
+                    greg = x.togregorian()
+                    greg = greg + pd.Timedelta(days=1)
+                    new_j = jdatetime.datetime.fromgregorian(datetime=greg)
+                    return jdatetime.datetime(new_j.year, new_j.month, new_j.day)
+                return jdatetime.datetime(x.year, x.month, x.day)
+            elif freq in ("h", "H"):
+                if x.minute >= 30:
+                    greg = x.togregorian()
+                    greg = greg + pd.Timedelta(hours=1)
+                    new_j = jdatetime.datetime.fromgregorian(datetime=greg)
+                    return jdatetime.datetime(
+                        new_j.year, new_j.month, new_j.day, new_j.hour
+                    )
+                return jdatetime.datetime(x.year, x.month, x.day, x.hour)
+            elif freq in ("min", "T"):
+                if x.second >= 30:
+                    greg = x.togregorian()
+                    greg = greg + pd.Timedelta(minutes=1)
+                    new_j = jdatetime.datetime.fromgregorian(datetime=greg)
+                    return jdatetime.datetime(
+                        new_j.year, new_j.month, new_j.day, new_j.hour, new_j.minute
+                    )
+                return jdatetime.datetime(x.year, x.month, x.day, x.hour, x.minute)
+            elif freq in ("s", "S"):
+                if x.microsecond >= 500000:
+                    greg = x.togregorian()
+                    greg = greg + pd.Timedelta(seconds=1)
+                    new_j = jdatetime.datetime.fromgregorian(datetime=greg)
+                    return jdatetime.datetime(
+                        new_j.year,
+                        new_j.month,
+                        new_j.day,
+                        new_j.hour,
+                        new_j.minute,
+                        new_j.second,
+                    )
+                return jdatetime.datetime(
+                    x.year, x.month, x.day, x.hour, x.minute, x.second
+                )
+            else:
+                raise ValueError(f"Unsupported frequency: {freq}")
+
+        return cast(pd.Series, self._obj.apply(round_date))
+
+    # -------------------------------------------------------------------------
+    # Timezone Methods
+    # -------------------------------------------------------------------------
+
+    def tz_localize(
+        self,
+        tz: dt_tzinfo | str | None,
+        ambiguous: str = "raise",
+        nonexistent: str = "raise",
+    ) -> pd.Series:
+        """Localize tz-naive dates to a timezone.
+
+        This converts the jdatetime objects to Gregorian, localizes them,
+        and returns the localized Gregorian datetimes.
+
+        Args:
+            tz: Timezone to localize to.
+            ambiguous: How to handle ambiguous times. Defaults to 'raise'.
+            nonexistent: How to handle nonexistent times. Defaults to 'raise'.
+
+        Returns:
+            Series of timezone-aware Gregorian datetimes.
+        """
+        self._validate()
+        gregorian = self.to_gregorian()
+        dt_series: pd.Series = pd.to_datetime(gregorian)
+        return cast(
+            pd.Series,
+            dt_series.dt.tz_localize(tz, ambiguous=ambiguous, nonexistent=nonexistent),
+        )
+
+    def tz_convert(self, tz: dt_tzinfo | str | None) -> pd.Series:
+        """Convert tz-aware dates to another timezone.
+
+        This converts the jdatetime objects to Gregorian, converts timezone,
+        and returns the converted Gregorian datetimes.
+
+        Args:
+            tz: Target timezone.
+
+        Returns:
+            Series of timezone-converted Gregorian datetimes.
+        """
+        self._validate()
+        gregorian = self.to_gregorian()
+        dt_series: pd.Series = pd.to_datetime(gregorian)
+        return cast(pd.Series, dt_series.dt.tz_convert(tz))
+
+
+__all__ = ["JalaliSeriesAccessor"]

--- a/jalali_pandas/df_handler.py
+++ b/jalali_pandas/df_handler.py
@@ -17,7 +17,6 @@ else:
     DataFrameGroupByT = DataFrameGroupByRuntime
 
 
-@pd.api.extensions.register_dataframe_accessor("jalali")
 class JalaliDataframeAccessor:
     """Accessor methods on pandas DataFrames to handle Jalali dates."""
 

--- a/jalali_pandas/serie_handler.py
+++ b/jalali_pandas/serie_handler.py
@@ -8,7 +8,6 @@ import jdatetime
 import pandas as pd
 
 
-@pd.api.extensions.register_series_accessor("jalali")
 class JalaliSerieAccessor:
     """Accessor methods on pandas series to handle Jalali dates."""
 

--- a/plans/8-implementation-roadmap.md
+++ b/plans/8-implementation-roadmap.md
@@ -46,6 +46,13 @@ This document outlines the phased implementation plan for building full Jalali c
 - Shifting works with JalaliDatetimeIndex and Timedelta/JalaliOffset
 - Comprehensive tests for all time series operations
 
+### Phase 5: Enhanced Accessors - ✅ COMPLETE
+- JalaliSeriesAccessor with all properties (dayofyear, daysinmonth, is_* flags)
+- JalaliSeriesAccessor with all methods (strftime, normalize, floor/ceil/round, tz_localize/tz_convert, month_name/day_name)
+- JalaliDataFrameAccessor with enhanced groupby, resample, convert_columns, filter methods
+- Full type annotations on both accessors
+- 76 new tests for accessor functionality
+
 ### Examples Created
 - `examples/01_basic_usage.py` - JalaliTimestamp basics
 - `examples/02_series_operations.py` - Series accessor usage
@@ -331,27 +338,35 @@ This document outlines the phased implementation plan for building full Jalali c
 ### Tasks
 
 #### 5.1 Series Accessor Enhancement
-- [ ] Update `jalali_pandas/accessors/series.py`
-- [ ] Add all missing properties (dayofyear, daysinmonth, is_* flags)
-- [ ] Add `strftime()` method
-- [ ] Add `normalize()` method
-- [ ] Add `floor()`, `ceil()`, `round()` methods
-- [ ] Add `tz_localize()`, `tz_convert()` methods
-- [ ] Add `month_name()`, `day_name()` methods
-- [ ] Add `date`, `time` properties
-- [ ] Add full type annotations
+- [x] Update `jalali_pandas/accessors/series.py`
+- [x] Add all missing properties (dayofyear, daysinmonth, is_* flags)
+- [x] Add `strftime()` method
+- [x] Add `normalize()` method
+- [x] Add `floor()`, `ceil()`, `round()` methods
+- [x] Add `tz_localize()`, `tz_convert()` methods
+- [x] Add `month_name()`, `day_name()` methods
+- [x] Add `date`, `time` properties
+- [x] Add full type annotations
 
 #### 5.2 DataFrame Accessor Enhancement
-- [ ] Update `jalali_pandas/accessors/dataframe.py`
-- [ ] Add `set_date_column()` method
-- [ ] Update `groupby()` to use new infrastructure
-- [ ] Implement `resample()` properly
-- [ ] Add `convert_columns()` method
-- [ ] Add full type annotations
+- [x] Update `jalali_pandas/accessors/dataframe.py`
+- [x] Add `set_date_column()` method
+- [x] Update `groupby()` to use new infrastructure
+- [x] Implement `resample()` properly
+- [x] Add `convert_columns()` method
+- [x] Add full type annotations
 
 ### Deliverables
 - Feature-complete accessors
 - Full type annotations
+
+### Completion Notes (2026-01-02)
+- Created `jalali_pandas/accessors/series.py` with JalaliSeriesAccessor class
+- Created `jalali_pandas/accessors/dataframe.py` with JalaliDataFrameAccessor class
+- Series accessor includes: all date/time properties, boolean flags (is_leap_year, is_month_start, etc.), strftime, normalize, floor/ceil/round, month_name/day_name, tz_localize/tz_convert
+- DataFrame accessor includes: set_date_column, groupby (extended), resample, convert_columns, to_period, filter_by_year/month/quarter/date_range
+- 76 new tests in `tests/test_accessors.py`
+- Total: 469 tests passing, 83% coverage
 
 ---
 

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -1,0 +1,627 @@
+"""Comprehensive tests for enhanced Series and DataFrame accessors."""
+
+from datetime import time
+
+import jdatetime
+import pandas as pd
+import pytest
+
+import jalali_pandas  # noqa: F401
+
+
+class TestJalaliSeriesAccessor:
+    """Test cases for JalaliSeriesAccessor."""
+
+    @pytest.fixture
+    def jalali_series(self) -> pd.Series:
+        """Create a test series with jdatetime objects."""
+        dates = [
+            jdatetime.datetime(1402, 1, 1, 10, 30, 45),  # Nowruz
+            jdatetime.datetime(1402, 3, 31, 12, 0, 0),  # End of Q1
+            jdatetime.datetime(1402, 6, 31, 0, 0, 0),  # End of Q2
+            jdatetime.datetime(1402, 9, 30, 23, 59, 59),  # End of Q3
+            jdatetime.datetime(1402, 12, 29, 0, 0, 0),  # End of year (non-leap)
+        ]
+        return pd.Series(dates)
+
+    @pytest.fixture
+    def gregorian_series(self) -> pd.Series:
+        """Create a test series with Gregorian dates."""
+        return pd.Series(pd.date_range("2023-03-21", periods=5, freq="D"))
+
+    # -------------------------------------------------------------------------
+    # Conversion Tests
+    # -------------------------------------------------------------------------
+
+    def test_to_jalali(self, gregorian_series: pd.Series) -> None:
+        """Test conversion from Gregorian to Jalali."""
+        result = gregorian_series.jalali.to_jalali()
+        assert len(result) == 5
+        assert result.iloc[0].year == 1402
+        assert result.iloc[0].month == 1
+        assert result.iloc[0].day == 1
+
+    def test_to_gregorian(self, jalali_series: pd.Series) -> None:
+        """Test conversion from Jalali to Gregorian."""
+        result = jalali_series.jalali.to_gregorian()
+        assert len(result) == 5
+        # 1402/1/1 = 2023/3/21
+        assert result.iloc[0].year == 2023
+        assert result.iloc[0].month == 3
+        assert result.iloc[0].day == 21
+
+    def test_parse_jalali(self) -> None:
+        """Test parsing string dates to jdatetime."""
+        s = pd.Series(["1402-01-01", "1402-06-15", "1402-12-29"])
+        result = s.jalali.parse_jalali("%Y-%m-%d")
+        assert result.iloc[0].year == 1402
+        assert result.iloc[1].month == 6
+        assert result.iloc[2].day == 29
+
+    # -------------------------------------------------------------------------
+    # Basic Property Tests
+    # -------------------------------------------------------------------------
+
+    def test_year_property(self, jalali_series: pd.Series) -> None:
+        """Test year property."""
+        result = jalali_series.jalali.year
+        assert (result == 1402).all()
+
+    def test_month_property(self, jalali_series: pd.Series) -> None:
+        """Test month property."""
+        result = jalali_series.jalali.month
+        assert list(result) == [1, 3, 6, 9, 12]
+
+    def test_day_property(self, jalali_series: pd.Series) -> None:
+        """Test day property."""
+        result = jalali_series.jalali.day
+        assert list(result) == [1, 31, 31, 30, 29]
+
+    def test_hour_property(self, jalali_series: pd.Series) -> None:
+        """Test hour property."""
+        result = jalali_series.jalali.hour
+        assert list(result) == [10, 12, 0, 23, 0]
+
+    def test_minute_property(self, jalali_series: pd.Series) -> None:
+        """Test minute property."""
+        result = jalali_series.jalali.minute
+        assert list(result) == [30, 0, 0, 59, 0]
+
+    def test_second_property(self, jalali_series: pd.Series) -> None:
+        """Test second property."""
+        result = jalali_series.jalali.second
+        assert list(result) == [45, 0, 0, 59, 0]
+
+    def test_quarter_property(self, jalali_series: pd.Series) -> None:
+        """Test quarter property."""
+        result = jalali_series.jalali.quarter
+        assert list(result) == [1, 1, 2, 3, 4]
+
+    def test_weekday_property(self, jalali_series: pd.Series) -> None:
+        """Test weekday property."""
+        result = jalali_series.jalali.weekday
+        assert len(result) == 5
+        # All values should be 0-6
+        assert all(0 <= x <= 6 for x in result)
+
+    def test_dayofweek_alias(self, jalali_series: pd.Series) -> None:
+        """Test dayofweek is alias for weekday."""
+        weekday = jalali_series.jalali.weekday
+        dayofweek = jalali_series.jalali.dayofweek
+        assert (weekday == dayofweek).all()
+
+    def test_dayofyear_property(self, jalali_series: pd.Series) -> None:
+        """Test dayofyear property."""
+        result = jalali_series.jalali.dayofyear
+        # 1402/1/1 = day 1
+        assert result.iloc[0] == 1
+        # 1402/3/31 = 31 + 31 + 31 = 93
+        assert result.iloc[1] == 93
+
+    def test_daysinmonth_property(self, jalali_series: pd.Series) -> None:
+        """Test daysinmonth property."""
+        result = jalali_series.jalali.daysinmonth
+        # Month 1 has 31 days, month 12 has 29 (non-leap)
+        assert result.iloc[0] == 31
+        assert result.iloc[4] == 29
+
+    def test_days_in_month_alias(self, jalali_series: pd.Series) -> None:
+        """Test days_in_month is alias for daysinmonth."""
+        daysinmonth = jalali_series.jalali.daysinmonth
+        days_in_month = jalali_series.jalali.days_in_month
+        assert (daysinmonth == days_in_month).all()
+
+    def test_week_property(self, jalali_series: pd.Series) -> None:
+        """Test week property."""
+        result = jalali_series.jalali.week
+        assert len(result) == 5
+        # All values should be 1-53
+        assert all(1 <= x <= 53 for x in result)
+
+    def test_weekofyear_alias(self, jalali_series: pd.Series) -> None:
+        """Test weekofyear is alias for week."""
+        week = jalali_series.jalali.week
+        weekofyear = jalali_series.jalali.weekofyear
+        assert (week == weekofyear).all()
+
+    # -------------------------------------------------------------------------
+    # Boolean Property Tests
+    # -------------------------------------------------------------------------
+
+    def test_is_leap_year(self) -> None:
+        """Test is_leap_year property."""
+        dates = [
+            jdatetime.datetime(1403, 1, 1),  # Leap year
+            jdatetime.datetime(1402, 1, 1),  # Non-leap year
+        ]
+        s = pd.Series(dates)
+        result = s.jalali.is_leap_year
+        assert result.iloc[0]
+        assert not result.iloc[1]
+
+    def test_is_month_start(self, jalali_series: pd.Series) -> None:
+        """Test is_month_start property."""
+        result = jalali_series.jalali.is_month_start
+        # Only first date (1402/1/1) is month start
+        assert result.iloc[0]
+        assert not result.iloc[1]
+
+    def test_is_month_end(self, jalali_series: pd.Series) -> None:
+        """Test is_month_end property."""
+        result = jalali_series.jalali.is_month_end
+        # Dates 2, 3, 4, 5 are month ends
+        assert not result.iloc[0]
+        assert result.iloc[1]  # 3/31
+        assert result.iloc[2]  # 6/31
+        assert result.iloc[3]  # 9/30
+        assert result.iloc[4]  # 12/29
+
+    def test_is_quarter_start(self) -> None:
+        """Test is_quarter_start property."""
+        dates = [
+            jdatetime.datetime(1402, 1, 1),  # Q1 start
+            jdatetime.datetime(1402, 4, 1),  # Q2 start
+            jdatetime.datetime(1402, 7, 1),  # Q3 start
+            jdatetime.datetime(1402, 10, 1),  # Q4 start
+            jdatetime.datetime(1402, 2, 1),  # Not quarter start
+        ]
+        s = pd.Series(dates)
+        result = s.jalali.is_quarter_start
+        assert list(result) == [True, True, True, True, False]
+
+    def test_is_quarter_end(self, jalali_series: pd.Series) -> None:
+        """Test is_quarter_end property."""
+        result = jalali_series.jalali.is_quarter_end
+        # 3/31, 6/31, 9/30, 12/29 are quarter ends
+        assert not result.iloc[0]  # 1/1
+        assert result.iloc[1]  # 3/31
+        assert result.iloc[2]  # 6/31
+        assert result.iloc[3]  # 9/30
+        assert result.iloc[4]  # 12/29
+
+    def test_is_year_start(self, jalali_series: pd.Series) -> None:
+        """Test is_year_start property."""
+        result = jalali_series.jalali.is_year_start
+        # Only 1/1 is year start
+        assert result.iloc[0]
+        assert not result.iloc[1]
+
+    def test_is_year_end(self, jalali_series: pd.Series) -> None:
+        """Test is_year_end property."""
+        result = jalali_series.jalali.is_year_end
+        # Only 12/29 (non-leap) is year end
+        assert not result.iloc[0]
+        assert result.iloc[4]
+
+    # -------------------------------------------------------------------------
+    # Date/Time Property Tests
+    # -------------------------------------------------------------------------
+
+    def test_date_property(self, jalali_series: pd.Series) -> None:
+        """Test date property returns dates at midnight."""
+        result = jalali_series.jalali.date
+        # All should have time = 0
+        assert result.iloc[0].hour == 0
+        assert result.iloc[0].minute == 0
+        assert result.iloc[0].second == 0
+
+    def test_time_property(self, jalali_series: pd.Series) -> None:
+        """Test time property returns Python time objects."""
+        result = jalali_series.jalali.time
+        assert isinstance(result.iloc[0], time)
+        assert result.iloc[0].hour == 10
+        assert result.iloc[0].minute == 30
+        assert result.iloc[0].second == 45
+
+    # -------------------------------------------------------------------------
+    # String Method Tests
+    # -------------------------------------------------------------------------
+
+    def test_strftime(self, jalali_series: pd.Series) -> None:
+        """Test strftime method."""
+        result = jalali_series.jalali.strftime("%Y/%m/%d")
+        assert result.iloc[0] == "1402/01/01"
+        assert result.iloc[1] == "1402/03/31"
+
+    def test_month_name_english(self, jalali_series: pd.Series) -> None:
+        """Test month_name with English locale."""
+        result = jalali_series.jalali.month_name(locale="en")
+        assert result.iloc[0] == "Farvardin"
+        assert result.iloc[1] == "Khordad"
+        assert result.iloc[4] == "Esfand"
+
+    def test_month_name_persian(self, jalali_series: pd.Series) -> None:
+        """Test month_name with Persian locale."""
+        result = jalali_series.jalali.month_name(locale="fa")
+        assert result.iloc[0] == "فروردین"
+        assert result.iloc[4] == "اسفند"
+
+    def test_day_name_english(self, jalali_series: pd.Series) -> None:
+        """Test day_name with English locale."""
+        result = jalali_series.jalali.day_name(locale="en")
+        # All should be valid day names
+        valid_names = [
+            "Shanbeh",
+            "Yekshanbeh",
+            "Doshanbeh",
+            "Seshanbeh",
+            "Chaharshanbeh",
+            "Panjshanbeh",
+            "Jomeh",
+        ]
+        assert all(name in valid_names for name in result)
+
+    def test_day_name_persian(self, jalali_series: pd.Series) -> None:
+        """Test day_name with Persian locale."""
+        result = jalali_series.jalali.day_name(locale="fa")
+        valid_names = [
+            "شنبه",
+            "یکشنبه",
+            "دوشنبه",
+            "سه‌شنبه",
+            "چهارشنبه",
+            "پنجشنبه",
+            "جمعه",
+        ]
+        assert all(name in valid_names for name in result)
+
+    # -------------------------------------------------------------------------
+    # Normalization Method Tests
+    # -------------------------------------------------------------------------
+
+    def test_normalize(self, jalali_series: pd.Series) -> None:
+        """Test normalize method sets time to midnight."""
+        result = jalali_series.jalali.normalize()
+        for dt in result:
+            assert dt.hour == 0
+            assert dt.minute == 0
+            assert dt.second == 0
+
+    def test_floor_day(self, jalali_series: pd.Series) -> None:
+        """Test floor to day."""
+        result = jalali_series.jalali.floor("D")
+        for dt in result:
+            assert dt.hour == 0
+            assert dt.minute == 0
+            assert dt.second == 0
+
+    def test_floor_hour(self, jalali_series: pd.Series) -> None:
+        """Test floor to hour."""
+        result = jalali_series.jalali.floor("h")
+        assert result.iloc[0].hour == 10
+        assert result.iloc[0].minute == 0
+        assert result.iloc[0].second == 0
+
+    def test_ceil_day(self) -> None:
+        """Test ceil to day."""
+        dates = [jdatetime.datetime(1402, 1, 1, 10, 30, 0)]
+        s = pd.Series(dates)
+        result = s.jalali.ceil("D")
+        # Should round up to next day
+        assert result.iloc[0].day == 2
+        assert result.iloc[0].hour == 0
+
+    def test_ceil_hour(self) -> None:
+        """Test ceil to hour."""
+        dates = [jdatetime.datetime(1402, 1, 1, 10, 30, 0)]
+        s = pd.Series(dates)
+        result = s.jalali.ceil("h")
+        assert result.iloc[0].hour == 11
+        assert result.iloc[0].minute == 0
+
+    def test_round_day(self) -> None:
+        """Test round to day."""
+        dates = [
+            jdatetime.datetime(1402, 1, 1, 10, 0, 0),  # Before noon
+            jdatetime.datetime(1402, 1, 1, 14, 0, 0),  # After noon
+        ]
+        s = pd.Series(dates)
+        result = s.jalali.round("D")
+        assert result.iloc[0].day == 1  # Rounds down
+        assert result.iloc[1].day == 2  # Rounds up
+
+    def test_round_hour(self) -> None:
+        """Test round to hour."""
+        dates = [
+            jdatetime.datetime(1402, 1, 1, 10, 20, 0),  # Before 30 min
+            jdatetime.datetime(1402, 1, 1, 10, 40, 0),  # After 30 min
+        ]
+        s = pd.Series(dates)
+        result = s.jalali.round("h")
+        assert result.iloc[0].hour == 10  # Rounds down
+        assert result.iloc[1].hour == 11  # Rounds up
+
+    def test_floor_invalid_freq(self, jalali_series: pd.Series) -> None:
+        """Test floor with invalid frequency raises error."""
+        with pytest.raises(ValueError):
+            jalali_series.jalali.floor("invalid")
+
+    # -------------------------------------------------------------------------
+    # NaT Handling Tests
+    # -------------------------------------------------------------------------
+
+    def test_properties_with_nat(self) -> None:
+        """Test properties handle NaT correctly."""
+        dates = [jdatetime.datetime(1402, 1, 1), pd.NaT]
+        s = pd.Series(dates)
+
+        year = s.jalali.year
+        assert year.iloc[0] == 1402
+        assert pd.isna(year.iloc[1])
+
+    def test_strftime_with_nat(self) -> None:
+        """Test strftime handles NaT correctly."""
+        dates = [jdatetime.datetime(1402, 1, 1), pd.NaT]
+        s = pd.Series(dates)
+        result = s.jalali.strftime("%Y-%m-%d")
+        assert result.iloc[0] == "1402-01-01"
+        assert result.iloc[1] is None
+
+
+class TestJalaliDataFrameAccessor:
+    """Test cases for JalaliDataFrameAccessor."""
+
+    @pytest.fixture
+    def jalali_df(self) -> pd.DataFrame:
+        """Create a test DataFrame with jdatetime column."""
+        dates = [
+            jdatetime.datetime(1402, 1, 1),
+            jdatetime.datetime(1402, 1, 15),
+            jdatetime.datetime(1402, 2, 1),
+            jdatetime.datetime(1402, 4, 1),
+            jdatetime.datetime(1402, 7, 1),
+        ]
+        return pd.DataFrame({"jdate": dates, "value": [10, 20, 30, 40, 50]})
+
+    # -------------------------------------------------------------------------
+    # Validation Tests
+    # -------------------------------------------------------------------------
+
+    def test_validation_no_jdate_column(self) -> None:
+        """Test validation fails without jdatetime column."""
+        df = pd.DataFrame(
+            {"date": pd.date_range("2023-01-01", periods=5), "value": range(5)}
+        )
+        with pytest.raises(ValueError, match="No jdatetime column found"):
+            _ = df.jalali
+
+    def test_set_date_column(self, jalali_df: pd.DataFrame) -> None:
+        """Test set_date_column method."""
+        accessor = jalali_df.jalali.set_date_column("jdate")
+        assert accessor.jdate == "jdate"
+
+    def test_set_date_column_invalid(self, jalali_df: pd.DataFrame) -> None:
+        """Test set_date_column with invalid column raises error."""
+        with pytest.raises(ValueError, match="not found"):
+            jalali_df.jalali.set_date_column("nonexistent")
+
+    # -------------------------------------------------------------------------
+    # Groupby Tests
+    # -------------------------------------------------------------------------
+
+    def test_groupby_year(self, jalali_df: pd.DataFrame) -> None:
+        """Test groupby by year."""
+        result = jalali_df.jalali.groupby("year").sum()
+        assert len(result) == 1  # All same year
+
+    def test_groupby_month(self, jalali_df: pd.DataFrame) -> None:
+        """Test groupby by month."""
+        result = jalali_df.jalali.groupby("month").sum()
+        assert len(result) == 4  # 4 unique months
+
+    def test_groupby_quarter(self, jalali_df: pd.DataFrame) -> None:
+        """Test groupby by quarter."""
+        result = jalali_df.jalali.groupby("quarter").sum()
+        assert len(result) == 3  # Q1, Q2, Q3
+
+    def test_groupby_ym(self, jalali_df: pd.DataFrame) -> None:
+        """Test groupby by year-month."""
+        result = jalali_df.jalali.groupby("ym").sum()
+        assert "__year" in result.index.names
+        assert "__month" in result.index.names
+
+    def test_groupby_yq(self, jalali_df: pd.DataFrame) -> None:
+        """Test groupby by year-quarter."""
+        result = jalali_df.jalali.groupby("yq").sum()
+        assert "__year" in result.index.names
+        assert "__quarter" in result.index.names
+
+    def test_groupby_invalid(self, jalali_df: pd.DataFrame) -> None:
+        """Test groupby with invalid key raises error."""
+        with pytest.raises(ValueError):
+            jalali_df.jalali.groupby("invalid")
+
+    # -------------------------------------------------------------------------
+    # Resample Tests
+    # -------------------------------------------------------------------------
+
+    def test_resample_month(self, jalali_df: pd.DataFrame) -> None:
+        """Test resample by month."""
+        result = jalali_df.jalali.resample("month")
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) > 0
+
+    def test_resample_quarter(self, jalali_df: pd.DataFrame) -> None:
+        """Test resample by quarter."""
+        result = jalali_df.jalali.resample("quarter")
+        assert isinstance(result, pd.DataFrame)
+
+    def test_resample_year(self, jalali_df: pd.DataFrame) -> None:
+        """Test resample by year."""
+        result = jalali_df.jalali.resample("year")
+        assert isinstance(result, pd.DataFrame)
+
+    def test_resample_week(self, jalali_df: pd.DataFrame) -> None:
+        """Test resample by week."""
+        result = jalali_df.jalali.resample("week")
+        assert isinstance(result, pd.DataFrame)
+
+    def test_resample_invalid(self, jalali_df: pd.DataFrame) -> None:
+        """Test resample with invalid type raises error."""
+        with pytest.raises(ValueError):
+            jalali_df.jalali.resample("invalid")
+
+    # -------------------------------------------------------------------------
+    # Convert Columns Tests
+    # -------------------------------------------------------------------------
+
+    def test_convert_columns_to_jalali(self, jalali_df: pd.DataFrame) -> None:
+        """Test convert_columns to Jalali."""
+        # Add a Gregorian column to convert
+        jalali_df["gdate"] = pd.date_range("2023-03-21", periods=5)
+        result = jalali_df.jalali.convert_columns("gdate", to_jalali=True)
+        assert result["gdate"].iloc[0].year == 1402
+
+    def test_convert_columns_to_gregorian(self, jalali_df: pd.DataFrame) -> None:
+        """Test convert_columns to Gregorian."""
+        result = jalali_df.jalali.convert_columns("jdate", to_jalali=False)
+        assert result["jdate"].iloc[0].year == 2023
+
+    def test_convert_columns_multiple(self, jalali_df: pd.DataFrame) -> None:
+        """Test convert_columns with multiple columns."""
+        # Add Gregorian columns to convert
+        jalali_df["gdate1"] = pd.date_range("2023-03-21", periods=5)
+        jalali_df["gdate2"] = pd.date_range("2023-06-21", periods=5)
+        result = jalali_df.jalali.convert_columns(["gdate1", "gdate2"], to_jalali=True)
+        assert result["gdate1"].iloc[0].year == 1402
+        assert result["gdate2"].iloc[0].year == 1402
+
+    def test_convert_columns_invalid(self, jalali_df: pd.DataFrame) -> None:
+        """Test convert_columns with invalid column raises error."""
+        with pytest.raises(ValueError, match="not found"):
+            jalali_df.jalali.convert_columns("nonexistent")
+
+    # -------------------------------------------------------------------------
+    # To Period Tests
+    # -------------------------------------------------------------------------
+
+    def test_to_period_year(self, jalali_df: pd.DataFrame) -> None:
+        """Test to_period with year frequency."""
+        result = jalali_df.jalali.to_period("Y")
+        assert "jdate_period" in result.columns
+        assert result["jdate_period"].iloc[0] == "1402"
+
+    def test_to_period_quarter(self, jalali_df: pd.DataFrame) -> None:
+        """Test to_period with quarter frequency."""
+        result = jalali_df.jalali.to_period("Q")
+        assert result["jdate_period"].iloc[0] == "1402Q1"
+
+    def test_to_period_month(self, jalali_df: pd.DataFrame) -> None:
+        """Test to_period with month frequency."""
+        result = jalali_df.jalali.to_period("M")
+        assert result["jdate_period"].iloc[0] == "1402-01"
+
+    def test_to_period_week(self, jalali_df: pd.DataFrame) -> None:
+        """Test to_period with week frequency."""
+        result = jalali_df.jalali.to_period("W")
+        assert "jdate_period" in result.columns
+        assert result["jdate_period"].iloc[0].startswith("1402W")
+
+    def test_to_period_day(self, jalali_df: pd.DataFrame) -> None:
+        """Test to_period with day frequency."""
+        result = jalali_df.jalali.to_period("D")
+        assert result["jdate_period"].iloc[0] == "1402-01-01"
+
+    # -------------------------------------------------------------------------
+    # Filter Tests
+    # -------------------------------------------------------------------------
+
+    def test_filter_by_year(self, jalali_df: pd.DataFrame) -> None:
+        """Test filter_by_year method."""
+        result = jalali_df.jalali.filter_by_year(1402)
+        assert len(result) == 5
+
+    def test_filter_by_year_list(self) -> None:
+        """Test filter_by_year with list of years."""
+        dates = [
+            jdatetime.datetime(1401, 1, 1),
+            jdatetime.datetime(1402, 1, 1),
+            jdatetime.datetime(1403, 1, 1),
+        ]
+        df = pd.DataFrame({"jdate": dates, "value": [1, 2, 3]})
+        result = df.jalali.filter_by_year([1401, 1402])
+        assert len(result) == 2
+
+    def test_filter_by_month(self, jalali_df: pd.DataFrame) -> None:
+        """Test filter_by_month method."""
+        result = jalali_df.jalali.filter_by_month(1)
+        assert len(result) == 2  # Two dates in month 1
+
+    def test_filter_by_month_list(self, jalali_df: pd.DataFrame) -> None:
+        """Test filter_by_month with list of months."""
+        result = jalali_df.jalali.filter_by_month([1, 2])
+        assert len(result) == 3
+
+    def test_filter_by_quarter(self, jalali_df: pd.DataFrame) -> None:
+        """Test filter_by_quarter method."""
+        result = jalali_df.jalali.filter_by_quarter(1)
+        assert len(result) == 3  # Q1 = months 1, 2, 3
+
+    def test_filter_by_date_range(self, jalali_df: pd.DataFrame) -> None:
+        """Test filter_by_date_range method."""
+        result = jalali_df.jalali.filter_by_date_range(
+            start="1402-01-01", end="1402-02-01"
+        )
+        assert len(result) == 3
+
+    def test_filter_by_date_range_start_only(self, jalali_df: pd.DataFrame) -> None:
+        """Test filter_by_date_range with start only."""
+        result = jalali_df.jalali.filter_by_date_range(start="1402-04-01")
+        assert len(result) == 2
+
+    def test_filter_by_date_range_end_only(self, jalali_df: pd.DataFrame) -> None:
+        """Test filter_by_date_range with end only."""
+        result = jalali_df.jalali.filter_by_date_range(end="1402-02-01")
+        assert len(result) == 3
+
+
+class TestAccessorEdgeCases:
+    """Test edge cases for accessors."""
+
+    def test_empty_series(self) -> None:
+        """Test accessor with empty series."""
+        s = pd.Series([], dtype=object)
+        # Should not raise during validation
+        result = s.jalali.to_jalali()
+        assert len(result) == 0
+
+    def test_empty_dataframe(self) -> None:
+        """Test accessor with empty DataFrame."""
+        df = pd.DataFrame({"jdate": [], "value": []})
+        # Empty DataFrame should raise since no jdatetime found
+        with pytest.raises(ValueError):
+            _ = df.jalali
+
+    def test_series_with_all_nat(self) -> None:
+        """Test series with all NaT values."""
+        s = pd.Series([pd.NaT, pd.NaT, pd.NaT])
+        result = s.jalali.to_jalali()
+        assert all(pd.isna(x) for x in result)
+
+    def test_leap_year_end(self) -> None:
+        """Test leap year end date."""
+        # 1403 is a leap year
+        dates = [jdatetime.datetime(1403, 12, 30)]
+        s = pd.Series(dates)
+        assert s.jalali.is_year_end.iloc[0]
+        assert s.jalali.daysinmonth.iloc[0] == 30


### PR DESCRIPTION
## Summary
This PR implements Phase 5 of the implementation roadmap: Enhanced Accessors.

### Task Reference
From `plans/8-implementation-roadmap.md`:
- 5.1 Series Accessor Enhancement
- 5.2 DataFrame Accessor Enhancement

### Changes

#### Series Accessor (`jalali_pandas/accessors/series.py`)
- All date/time properties: year, month, day, hour, minute, second, microsecond, nanosecond
- Derived properties: quarter, weekday, dayofweek, dayofyear, daysinmonth, week, weekofyear
- Boolean flags: is_leap_year, is_month_start, is_month_end, is_quarter_start, is_quarter_end, is_year_start, is_year_end
- Date/time properties: date, time
- String methods: strftime(), month_name(locale), day_name(locale)
- Normalization: normalize(), floor(), ceil(), round()
- Timezone: tz_localize(), tz_convert()

#### DataFrame Accessor (`jalali_pandas/accessors/dataframe.py`)
- set_date_column() for explicit column selection
- Enhanced groupby() with quarter, dayofyear, week options
- resample() with week support
- convert_columns() for batch Jalali/Gregorian conversion
- to_period() for period representation (Y, Q, M, W, D)
- filter_by_year(), filter_by_month(), filter_by_quarter()
- filter_by_date_range() for date range filtering

### Acceptance Criteria
- [x] Series accessor with all properties/methods
- [x] DataFrame accessor with all methods
- [x] Full type annotations
- [x] Comprehensive tests

### Test Coverage
- 76 new tests in `tests/test_accessors.py`
- Total: 469 tests passing
- Coverage: 83%

### Verification
```bash
uv run pytest --cov=jalali_pandas
# 469 passed, 83% coverage
```