### PR TITLE
Add Phase 8 implementation prompt

### DIFF
--- a/plans/phase8-release-automation-prompt.md
+++ b/plans/phase8-release-automation-prompt.md
@@ -1,0 +1,48 @@
+# Prompt: Implement Phase 8 Release & Documentation Automation
+
+You are tasked with implementing the Phase 8 automation scope defined in `plans/8-implementation-roadmap.md` and `plans/tasks/phase8-release-automation.md`. Follow these directives strictly.
+
+## Objectives
+- Automate packaging and publishing to TestPyPI/PyPI with trusted publishing.
+- Automate versioning/changelog management and release-note generation.
+- Automate docs build/versioning and publishing to GitHub Pages.
+- Provide a release checklist for human verification.
+
+## Constraints & Standards
+- Use `uv` for dependency install and invocation where applicable.
+- Keep version source of truth synchronized between `pyproject.toml` and `jalali_pandas/__init__.py`.
+- Preserve Keep a Changelog format in `CHANGELOG.md`.
+- Follow repo coding standards in `AGENTS.md` (Ruff formatting, 88-char lines, typed public APIs).
+
+## Work Items
+1. **Release Tooling (`scripts/release/`)**
+   - Add `build.py` (or `build.sh`) to clean `dist/`, build sdist/wheel via `uv run python -m build`, and run `uv run twine check dist/*`.
+   - Add `bump_version.py` to update both `pyproject.toml` and `jalali_pandas/__init__.py`; support prerelease suffixes and dry-run flag.
+   - Add `changelog.py` helper to move "Unreleased" entries into a new version section with date when tagging.
+   - Provide a `README.md` in `scripts/release/` explaining usage.
+
+2. **CI Workflows**
+   - Create `.github/workflows/release.yml` triggered on tags `v*` and manual `workflow_dispatch` with a `dry_run` input.
+   - Steps: checkout with `fetch-depth: 0`; set up Python + uv cache; install deps; run `ruff check`, format check, `pytest`, type checks; build artifacts; run `twine check`; publish to TestPyPI for prerelease tags and PyPI for stable using trusted publishing; upload dist/ and logs as artifacts.
+   - Add gate for release approval (required reviewer or environment protection) before publish job runs.
+   - Add `.github/workflows/docs.yml` to build docs on PRs and publish to `gh-pages` on tags; include API reference generation and cache; host under `/latest/` and `/vX.Y.Z/`.
+   - If using Release Drafter, add `.github/release-drafter.yml` and ensure workflow exists/updated.
+
+3. **Docs Versioning & Execution**
+   - Configure MkDocs with version switcher (e.g., `mkdocs-material` versioning plugin or static selector) to publish latest + tag paths.
+   - Automate API docs with `mkdocs-gen-files`/`mkdocstrings` during CI; ensure config lives in `docs/` or `mkdocs.yml`.
+   - Add CI validation for examples/notebooks (execute or sanity-check) to prevent stale content.
+
+4. **Release Checklist**
+   - Add `docs/release-checklist.md` (or update existing) covering: changelog completeness, version bump, lint/tests/docs build commands, signed tag creation (`git tag -s vX.Y.Z`), CI publish confirmation, docs deployment verification, announcement links.
+
+## Acceptance Criteria
+- Tagging a version triggers CI that lint/tests/builds/publishes artifacts and docs automatically; dry-run path available.
+- Changelog and version numbers remain in sync across metadata and docs.
+- Docs site publishes latest and tagged versions to GitHub Pages.
+- Scripts include usage docs and support dry-run/validation.
+
+## Delivery Instructions
+- Update relevant docs (README, CHANGELOG, `plans/8-implementation-roadmap.md` if necessary) to reflect automation.
+- Add tests/smoke checks for new scripts where feasible.
+- Ensure commits are clean and CI configurations reference pinned tool versions.

--- a/plans/tasks/phase8-release-automation.md
+++ b/plans/tasks/phase8-release-automation.md
@@ -1,0 +1,44 @@
+# Task: Implement Phase 8 Release & Documentation Automation
+
+## Objective
+Deliver the automation and human-in-the-loop steps defined in Phase 8 of the implementation roadmap so releases can be cut, validated, and published with minimal manual effort.
+
+## Scope
+- Build tooling/scripts to automate version bumps, packaging, and publishing.
+- Add CI workflows that validate, build, and deploy artifacts to TestPyPI/PyPI and GitHub Pages.
+- Wire changelog/version management and documentation automation to keep releases consistent.
+
+## Deliverables
+- `scripts/release/` utilities to bump versions, clean artifacts, and build sdist/wheel.
+- GitHub Actions workflows for release publishing and docs build/deploy with dry-run support.
+- Automated changelog updates and release notes generation tied to version tags.
+- Versioned documentation published to GitHub Pages (latest + tagged versions).
+- Release checklist capturing the required manual verifications.
+
+## Work Breakdown
+1. **Packaging & Publishing Automation**
+   - Create a consolidated release script (`scripts/release/build.py` or `release.sh`) that cleans `dist/` and builds artifacts via `uv run python -m build`.
+   - Add a GitHub Actions release workflow triggered on `v*` tags that runs lint, tests, type checks, builds artifacts, runs `uv run twine check dist/*`, and publishes to TestPyPI for prereleases or PyPI for stable tags using trusted publishing.
+   - Provide a manual `workflow_dispatch` dry-run path and upload build logs/artifacts for traceability.
+   - Document required repository permissions/secrets and how to opt into trusted publishing.
+
+2. **Versioning & Changelog Management**
+   - Establish a single version source of truth (e.g., `jalali_pandas/__init__.py` synced with `pyproject.toml`) and add a helper to bump both.
+   - Adopt or refine Keep a Changelog sections, wiring automation to move entries from Unreleased to release sections during tagging.
+   - Configure Release Drafter (or similar) to assemble release notes from merged PRs/labels, and gate publishing on approval.
+
+3. **Documentation Automation**
+   - Add a docs workflow that runs `uv run mkdocs build --strict` on PRs and publishes to `gh-pages` on tags.
+   - Implement docs versioning (latest + per-tag paths) and automate API reference generation with `mkdocs-gen-files`/`mkdocstrings`.
+   - Validate or execute examples/notebooks in CI to prevent stale docs content.
+
+4. **Release Checklist (Human-in-the-loop)**
+   - Verify changelog completeness and version bumps before tagging.
+   - Run `uv run pytest`, `uv run ruff check`, and docs build locally or via CI gates.
+   - Create a signed tag (`git tag -s vX.Y.Z`), push, and confirm TestPyPI/PyPI uploads and docs deployment.
+   - Publish announcement links once artifacts and docs are live.
+
+## Success Criteria
+- Tagging a release triggers CI that validates, builds, and publishes artifacts and docs without manual patching.
+- Changelog entries and version numbers stay in sync across code, package metadata, and published docs.
+- Dry-run workflows enable safe rehearsal of releases.


### PR DESCRIPTION
## Summary
- add a detailed execution prompt for Phase 8 release and documentation automation
- outline objectives, work items, acceptance criteria, and delivery instructions for the automation task

## Testing
- Not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69592a8f2084832bac3727bc60fcee44)